### PR TITLE
Auto-install linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 linter-phpmd
 =========================
 
-This linter plugin for [Linter](https://github.com/AtomLinter/Linter) provides an interface to [phpmd](http://phpmd.org/documentation/index.html). It will be used with files that have the “PHP” and “HTML” syntax.
+This linter plugin for [Linter](https://github.com/AtomLinter/Linter) provides an interface to [phpmd](http://phpmd.org/documentation/index.html). It will be used with files that have the “PHP” syntax or PHP embedded within HTML.
 
 ## Installation
-Linter package must be installed in order to use this plugin. If Linter is not installed, please follow the instructions [here](https://github.com/AtomLinter/Linter).
-
 ### phpmd installation
 Before installing this plugin, you must ensure that `phpmd` is installed on your system. To install `phpmd`, do the following:
 
@@ -20,7 +18,7 @@ Before installing this plugin, you must ensure that `phpmd` is installed on your
  pear install --alldeps phpmd/PHP_PMD
  ```
 
-Now you can proceed to install the linter-phpmd plugin.
+After verifying that `phpmd` works from your terminal, proceed to install the linter-phpmd plugin.
 
 ### Plugin installation
 ```ShellSession
@@ -31,18 +29,18 @@ $ apm install linter-phpmd
 You can configure linter-phpmd by editing ~/.atom/config.cson (choose Open Your Config in Atom menu):
 ```cson
 'linter-phpmd':
-  'executablePath': null #phpmd path. run 'which phpmd' to find the path
+  'executablePath': null #phpmd path. run `which phpmd` to find the path
   'rulesets': 'cleancode,codesize,controversial,design,naming,unusedcode' #phpmd rulesets
 ```
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 
-1. Fork the plugin repository.
-1. Hack on a separate topic branch created from the latest `master`.
-1. Commit and push the topic branch.
-1. Make a pull request.
-1. welcome to the club
+0. Fork the plugin repository.
+0. Hack on a separate topic branch created from the latest `master`.
+0. Commit and push the topic branch.
+0. Make a pull request.
+0. welcome to the club
 
 Please note that modifications should follow these coding guidelines:
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -13,6 +13,7 @@ module.exports =
       description: 'Comma separated list of rulesets to use in phpmd.'
 
   activate: ->
+    require("atom-package-deps").install("linter-phpmd")
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.config.observe 'linter-phpmd.executablePath',
       (executablePath) =>

--- a/package.json
+++ b/package.json
@@ -6,8 +6,12 @@
   "repository": "https://github.com/AtomLinter/linter-phpmd",
   "license": "MIT",
   "dependencies": {
-    "atom-linter": "^2.0.1"
+    "atom-linter": "^3.0.0",
+    "atom-package-deps": "^2.0.5"
   },
+  "package-deps": [
+    "linter"
+  ],
   "providedServices": {
     "linter": {
       "versions": {


### PR DESCRIPTION
Use `atom-package-deps` to automatically install `linter` if it isn't already installed.

Closes #14.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-phpmd/15)
<!-- Reviewable:end -->
