### PR TITLE
Add a coffeelint.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ If you would like to contribute enhancements or fixes, please do the following:
 0. Hack on a separate topic branch created from the latest `master`.
 0. Commit and push the topic branch.
 0. Make a pull request.
-0. welcome to the club
+0. Welcome to the club!
 
 Please note that modifications should follow these coding guidelines:
 
 - Indent is 2 spaces.
-- Code should pass coffeelint linter.
+- Code should pass [CoffeeLint](http://www.coffeelint.org/) with the provided `coffeelint.json`.
 - Vertical whitespace helps readability, don’t be afraid to use it.
 
 Thank you for helping out!

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,135 @@
+{
+  "arrow_spacing": {
+    "level": "error"
+  },
+  "braces_spacing": {
+    "level": "error",
+    "spaces": 0,
+    "empty_object_spaces": 0
+  },
+  "camel_case_classes": {
+    "level": "error"
+  },
+  "coffeescript_error": {
+    "level": "error"
+  },
+  "colon_assignment_spacing": {
+    "level": "error",
+    "spacing": {
+      "left": 0,
+      "right": 1
+    }
+  },
+  "cyclomatic_complexity": {
+    "value": 10,
+    "level": "ignore"
+  },
+  "duplicate_key": {
+    "level": "error"
+  },
+  "empty_constructor_needs_parens": {
+    "level": "ignore"
+  },
+  "ensure_comprehensions": {
+    "level": "warn"
+  },
+  "eol_last": {
+    "level": "ignore"
+  },
+  "indentation": {
+    "value": 2,
+    "level": "error"
+  },
+  "line_endings": {
+    "level": "ignore",
+    "value": "unix"
+  },
+  "max_line_length": {
+    "value": 120,
+    "level": "warn",
+    "limitComments": true
+  },
+  "missing_fat_arrows": {
+    "level": "ignore",
+    "is_strict": false
+  },
+  "newlines_after_classes": {
+    "value": 3,
+    "level": "ignore"
+  },
+  "no_backticks": {
+    "level": "error"
+  },
+  "no_debugger": {
+    "level": "error",
+    "console": false
+  },
+  "no_empty_functions": {
+    "level": "ignore"
+  },
+  "no_empty_param_list": {
+    "level": "error"
+  },
+  "no_implicit_braces": {
+    "level": "ignore",
+    "strict": true
+  },
+  "no_implicit_parens": {
+    "strict": true,
+    "level": "ignore"
+  },
+  "no_interpolation_in_single_quotes": {
+    "level": "error"
+  },
+  "no_nested_string_interpolation": {
+    "level": "warn"
+  },
+  "no_plusplus": {
+    "level": "ignore"
+  },
+  "no_private_function_fat_arrows": {
+    "level": "warn"
+  },
+  "no_stand_alone_at": {
+    "level": "error"
+  },
+  "no_tabs": {
+    "level": "error"
+  },
+  "no_this": {
+    "level": "ignore"
+  },
+  "no_throwing_strings": {
+    "level": "error"
+  },
+  "no_trailing_semicolons": {
+    "level": "error"
+  },
+  "no_trailing_whitespace": {
+    "level": "error",
+    "allowed_in_comments": false,
+    "allowed_in_empty_lines": true
+  },
+  "no_unnecessary_double_quotes": {
+    "level": "error"
+  },
+  "no_unnecessary_fat_arrows": {
+    "level": "warn"
+  },
+  "non_empty_constructor_needs_parens": {
+    "level": "ignore"
+  },
+  "prefer_english_operator": {
+    "level": "error",
+    "doubleNotLevel": "ignore"
+  },
+  "space_operators": {
+    "level": "ignore"
+  },
+  "spacing_after_comma": {
+    "level": "error"
+  },
+  "transform_messes_up_line_numbers": {
+    "level": "warn"
+  }
+}

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -13,7 +13,7 @@ module.exports =
       description: 'Comma separated list of rulesets to use in phpmd.'
 
   activate: ->
-    require("atom-package-deps").install("linter-phpmd")
+    require('atom-package-deps').install('linter-phpmd')
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.config.observe 'linter-phpmd.executablePath',
       (executablePath) =>


### PR DESCRIPTION
Adds a `coffeelint.json` and fixes the one minor linter error it exposes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-phpmd/16)
<!-- Reviewable:end -->
