### PR TITLE
Don't force enabling of linter

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -13,7 +13,7 @@ module.exports =
       description: 'Comma separated list of rulesets to use in phpmd.'
 
   activate: ->
-    require('atom-package-deps').install('linter-phpmd')
+    require('atom-package-deps').install('linter-phpmd', false)
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.config.observe 'linter-phpmd.executablePath',
       (executablePath) =>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "atom-linter": "^3.0.0",
-    "atom-package-deps": "^2.0.5"
+    "atom-package-deps": "^2.1.2"
   },
   "package-deps": [
     "linter"


### PR DESCRIPTION
Explicitly tell `atom-package-deps` not to force enabling of the `linter` package on every launch of this package.

If the user doesn't have `linter` installed in the first place it will still be enabled on install.

Pointed out by @nmote in https://github.com/AtomLinter/linter-eslint/issues/212#issuecomment-141222987.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-phpmd/17)
<!-- Reviewable:end -->
