### PR TITLE
Add linter name

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -28,6 +28,7 @@ module.exports =
   provideLinter: ->
     helpers = require('atom-linter')
     provider =
+      name: 'PHPMD'
       grammarScopes: ['text.html.php', 'source.php']
       scope: 'file'
       lintOnFly: false


### PR DESCRIPTION
Specifies the linter name, allowing the `linter` package to display it if the user chooses to.