### PR TITLE
Fix bug if no ruleset.xml present

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -48,12 +48,11 @@ module.exports =
       lint: (textEditor) =>
         filePath = textEditor.getPath()
         command = @executablePath
+        ruleset = @rulesets
         if @projectRules
           rulesetPath = helpers.findFile(filePath, 'ruleset.xml')
-          if rulesetPath.length
+          if rulesetPath is not null and rulesetPath.length > 0
             ruleset = rulesetPath
-        else
-          ruleset = @rulesets
         parameters = []
         parameters.push(filePath)
         parameters.push('text')


### PR DESCRIPTION
If no `ruleset.xml` file was present it would attempt to access the `length` property of null, which would fail. This makes the package work again when no `ruleset.xml` file exists.