### PR TITLE
Properly check the return of findFile

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -51,8 +51,7 @@ module.exports =
         ruleset = @rulesets
         if @projectRules
           rulesetPath = helpers.findFile(filePath, 'ruleset.xml')
-          if rulesetPath is not null and rulesetPath.length > 0
-            ruleset = rulesetPath
+          ruleset = rulesetPath if rulesetPath?
         parameters = []
         parameters.push(filePath)
         parameters.push('text')


### PR DESCRIPTION
The last "fix" fixed it for when no `ruleset.xml` file existed... but broke it for when it does exist. This works in both cases.