### PR TITLE
Add a spec suite

### DIFF
--- a/spec/files/bad.php
+++ b/spec/files/bad.php
@@ -1,0 +1,3 @@
+<?php
+function a() {
+}

--- a/spec/files/good.php
+++ b/spec/files/good.php
@@ -1,0 +1,2 @@
+<?php
+echo 'Hello world';

--- a/spec/linter-phpmd-spec.js
+++ b/spec/linter-phpmd-spec.js
@@ -1,0 +1,79 @@
+"use babel";
+
+describe('The phpmd provider for Linter', () => {
+  const lint = require('../lib/main').provideLinter().lint;
+
+  beforeEach(() => {
+    atom.workspace.destroyActivePaneItem();
+    waitsForPromise(() => {
+      atom.packages.activatePackage('linter-phpmd');
+      return atom.packages.activatePackage('language-php').then(() =>
+        atom.workspace.open(__dirname + '/files/good.php')
+      );
+    });
+  });
+
+  it('should be in the packages list', () => {
+    return expect(atom.packages.isPackageLoaded('linter-phpmd')).toBe(true);
+  });
+
+  it('should be an active package', () => {
+    return expect(atom.packages.isPackageActive('linter-phpmd')).toBe(true);
+  });
+
+  describe('checks bad.php and', () => {
+    let editor = null;
+    beforeEach(() => {
+      waitsForPromise(() => {
+        return atom.workspace.open(__dirname + '/files/bad.php').then(openEditor => {
+          editor = openEditor;
+        });
+      });
+    });
+
+    it('finds at least one message', () => {
+      waitsForPromise(() => {
+        return lint(editor).then(messages => {
+          expect(messages.length).toBeGreaterThan(0);
+        });
+      });
+    });
+
+    it('verifies the first message', () => {
+      waitsForPromise(() => {
+        return lint(editor).then(messages => {
+          expect(messages[0].type).toBeDefined();
+          expect(messages[0].type).toEqual('Error');
+          expect(messages[0].text).toBeDefined();
+          expect(messages[0].text).toEqual('Avoid using short method names like ' +
+            '::a(). The configured minimum method name length is 3.');
+          expect(messages[0].filePath).toBeDefined();
+          expect(messages[0].filePath).toMatch(/.+bad\.php$/);
+          expect(messages[0].range).toBeDefined();
+          expect(messages[0].range.length).toEqual(2);
+          expect(messages[0].range).toEqual([[1, 0], [1, 0]]);
+        });
+      });
+    });
+  });
+
+  it('finds nothing wrong with an empty file', () => {
+    waitsForPromise(() => {
+      return atom.workspace.open(__dirname + '/files/empty.php').then(editor => {
+        return lint(editor).then(messages => {
+          expect(messages.length).toEqual(0);
+        });
+      });
+    });
+  });
+
+  it('finds nothing wrong with a valid file', () => {
+    waitsForPromise(() => {
+      return atom.workspace.open(__dirname + '/files/good.php').then(editor => {
+        return lint(editor).then(messages => {
+          expect(messages.length).toEqual(0);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds some specs testing basic functionality. Assumes no configuration of the path to `phpmd` is required.