### PR TITLE
Ability to specify ruleset filename

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -11,16 +11,8 @@ module.exports =
       type: 'string'
       title: 'PHPMD Rulesets'
       default: 'cleancode,codesize,controversial,design,naming,unusedcode'
-      description: 'Comma separated list of rulesets to use in phpmd.'
+      description: 'Comma separated list of rulesets to use in phpmd. You can also enter the name of your ruleset file (example: `ruleset.xml`) to load that from the current file\'s directory (or any of the parent directories) '
       order: 2
-    projectRules:
-      title: 'Automatically use ruleset.xml'
-      type: 'boolean'
-      default: false
-      description: 'Attempt to automatically find and use a `ruleset.xml` ' +
-        'file in the current file\'s directory or any parent directories. ' +
-        'Overrides any rulesets defined above.'
-      order: 3
 
   activate: ->
     require('atom-package-deps').install()
@@ -31,9 +23,6 @@ module.exports =
     @subscriptions.add atom.config.observe 'linter-phpmd.rulesets',
       (rulesets) =>
         @rulesets = rulesets
-    @subscriptions.add atom.config.observe 'linter-phpmd.projectRules',
-      (projectRules) =>
-        @projectRules = projectRules
 
   deactivate: ->
     @subscriptions.dispose()
@@ -49,8 +38,8 @@ module.exports =
         filePath = textEditor.getPath()
         command = @executablePath
         ruleset = @rulesets
-        if @projectRules
-          rulesetPath = helpers.find(filePath, 'ruleset.xml')
+        if /^[a-z0-9]+\.xml$/gi.test(@rulesets)
+          rulesetPath = helpers.find(filePath, @rulesets)
           ruleset = rulesetPath if rulesetPath?
         parameters = []
         parameters.push(filePath)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -30,7 +30,7 @@ module.exports =
     atom.config.get('linter-phpmd.rulesets') == 
     atom.config.defaultSettings['linter-phpmd'].rulesets
       atom.unset('linter-phpmd.projectRules')
-      atom.set('linter-phpmd.rulesets')
+      atom.set('linter-phpmd.rulesets', 'ruleset.xml')
     else if atom.config.get('linter-phpmd.projectRules') == true
       atom.unset('linter-phpmd.projectRules')
       atom.notifications.addInfo('You need to update your ' +

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -26,6 +26,20 @@ module.exports =
     @subscriptions.add atom.config.observe 'linter-phpmd.rulesets',
       (rulesets) =>
         @rulesets = rulesets
+    if atom.config.get('linter-phpmd.projectRules') == true && 
+    atom.config.get('linter-phpmd.rulesets') == 
+    atom.config.defaultSettings['linter-phpmd'].rulesets
+      atom.unset('linter-phpmd.projectRules')
+      atom.set('linter-phpmd.rulesets')
+    else if atom.config.get('linter-phpmd.projectRules') == true
+      atom.unset('linter-phpmd.projectRules')
+      atom.notifications.addInfo('You need to update your ' +
+      '`linter-phpmd` settings', {
+        detail: 'The automatic searching for ruleset.xml feature is no ' +
+        'longer a separate setting. Enter "ruleset.xml" in the ' +
+        '"PHPMD Rulesets" to restore previous behavior.',
+        dismissable: true
+      })
 
   deactivate: ->
     @subscriptions.dispose()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -12,7 +12,7 @@ module.exports =
       title: 'PHPMD Rulesets'
       default: 'cleancode,codesize,controversial,design,naming,unusedcode '
       description: 'Comma separated list of rulesets to use in phpmd. ' +
-                   'You can also enter the name of your ruleset file' + 
+                   'You can also enter the name of your ruleset file' +
                    '(example: `ruleset.xml`) to load that from the current ' +
                    'file\'s directory (or any of the parent directories)'
       order: 2

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,8 +10,11 @@ module.exports =
     rulesets:
       type: 'string'
       title: 'PHPMD Rulesets'
-      default: 'cleancode,codesize,controversial,design,naming,unusedcode'
-      description: 'Comma separated list of rulesets to use in phpmd. You can also enter the name of your ruleset file (example: `ruleset.xml`) to load that from the current file\'s directory (or any of the parent directories) '
+      default: 'cleancode,codesize,controversial,design,naming,unusedcode '
+      description: 'Comma separated list of rulesets to use in phpmd. ' +
+                   'You can also enter the name of your ruleset file' + 
+                   '(example: `ruleset.xml`) to load that from the current ' +
+                   'file\'s directory (or any of the parent directories)'
       order: 2
 
   activate: ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -45,7 +45,11 @@ module.exports =
         parameters.push(filePath)
         parameters.push('text')
         parameters.push(ruleset)
-        return helpers.exec(command, parameters).then (output) ->
+        options = {}
+        projectDir = atom.project.relativizePath(filePath)[0]
+        if projectDir?
+          options.cwd = projectDir
+        return helpers.exec(command, parameters, options).then (output) ->
           regex = '(?<file>.+):(?<line>[0-9]+)\t*(?<message>.+)'
           return helpers.parse(output, regex).map (error) ->
             error.type = 'Error'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "linter-phpmd",
   "main": "./lib/main.coffee",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Lint PHP on the fly, using phpmd",
   "repository": "https://github.com/AtomLinter/linter-phpmd",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "linter-phpmd",
   "main": "./lib/main.coffee",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.4.1",
   "description": "Lint PHP on the fly, using phpmd",
   "repository": "https://github.com/AtomLinter/linter-phpmd",
   "license": "MIT",


### PR DESCRIPTION
PHPMD allows you to actually enter a filename path in the ruleset
command itself, but it requires you to enter the path.
This commit allows passing a simple filename, and if it detects a xml
filename passed without being a relative or absolute path it'll look in
the current or parent directories to find the file.

Fixes #58