### PR TITLE
Fix PHP on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,12 @@ environment:
     - ATOM_CHANNEL: beta
 
 install:
+  # Update Chocolatey
+  - choco upgrade chocolatey -y
+  # Enable Windows Update
+  # This is required for one of the dependencies of the Chocolatey PHP package
+  - sc config wuauserv start= auto
+  - net start wuauserv
   # The following installs and sets up PHP
   - cinst -y php
   - cd c:\tools\php


### PR DESCRIPTION
Update Chocolatey to the current released version as the one on AppVeyor is exhibiting a bug we are running into. Also enables the Windows Update service as it is required by KB2919442 which is a dependency of the PHP package.