### PR TITLE
Fix Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,8 @@ git:
 
 sudo: false
 
+dist: trusty
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,41 +10,17 @@ matrix:
       language: php
       php: 5.6
       env: ATOM_CHANNEL=stable
-      install:
-        # Set the GitHub OAuth token for Composer
-        - composer config -g github-oauth.github.com "$COMPOSER_OAUTH_TOKEN"
-        - export PATH="$PATH:$HOME/.composer/vendor/bin"
-        # Install PHPMD
-        - composer global require "phpmd/phpmd"
-
     - os: linux
       language: php
       php: 7.0
       env: ATOM_CHANNEL=beta
-      install:
-        # Set the GitHub OAuth token for Composer
-        - composer config -g github-oauth.github.com "$COMPOSER_OAUTH_TOKEN"
-        - export PATH="$PATH:$HOME/.composer/vendor/bin"
-        # Install PHPMD
-        - composer global require "phpmd/phpmd"
 
-    - os: osx
-      # Note: The OSX builds do not natively support PHP, so the order is swapped
-      #  from the Linux builds.
-      # Installed for linting the project
-      language: generic
-      env: ATOM_CHANNEL=stable
-      install:
-        # Install PHP 5.6
-        - curl -s http://php-osx.liip.ch/install.sh | bash -s 5.6
-        - export PATH="/usr/local/php5/bin:$PATH"
-        # Install Composer
-        - php -r "readfile('https://getcomposer.org/installer');" | sudo php -- --filename=composer
-        - export PATH="$PATH:$HOME/.composer/vendor/bin"
-        # Set the GitHub OAuth token for Composer
-        - sudo php composer config -g github-oauth.github.com "$COMPOSER_OAUTH_TOKEN"
-        # Install PHPMD
-        - sudo php composer global require "phpmd/phpmd"
+install:
+  # Set the GitHub OAuth token for Composer
+  - composer config -g github-oauth.github.com "$COMPOSER_OAUTH_TOKEN"
+  - export PATH="$PATH:$HOME/.composer/vendor/bin"
+  # Install PHPMD
+  - composer global require "phpmd/phpmd"
 
 before_script:
   - phpmd --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       env: ATOM_CHANNEL=stable
     - os: linux
       language: php
-      php: 7.0
+      php: 7.1
       env: ATOM_CHANNEL=beta
 
 install:


### PR DESCRIPTION
Atom requires Trusty at minimum, without a lot of massaging that is
problematic on CI builds.