### PR TITLE
Update CI Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 env:
   global:
     - COMPOSER_DISABLE_XDEBUG_WARN="1"
-    - COMPOSER_OAUTH_TOKEN="cc4a091c096e7d3cfe053c3f669fb840be60ab98"
 
 os: linux
 language: php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 ### Project specific config ###
+os: linux
+language: php
 env:
   global:
     - COMPOSER_DISABLE_XDEBUG_WARN="1"
-
-os: linux
-language: php
 
 jobs:
   include:
@@ -41,7 +40,7 @@ jobs:
 install:
   # Set the GitHub OAuth token for Composer
   - composer config -g github-oauth.github.com "$COMPOSER_OAUTH_TOKEN"
-  - export PATH="$PATH:$HOME/.composer/vendor/bin"
+  - export PATH="$PATH:$HOME/.config/composer/vendor/bin"
   # Install PHPMD
   - composer global require "phpmd/phpmd"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 ### Project specific config ###
 environment:
-  COMPOSER_OAUTH_TOKEN: "cc4a091c096e7d3cfe053c3f669fb840be60ab98"
+  COMPOSER_OAUTH_TOKEN:
+    secure: PY0tnExp9ix66O1q0TuLbVwUg3YS6PIzFuI7B/3vUt8xPtLejPRlE4ewGTbgzmWH
   COMPOSER_DISABLE_XDEBUG_WARN: "1"
 
   matrix:
@@ -24,7 +25,10 @@ install:
   - SET PATH=C:\tools\php72\;%PATH%
   # Install Composer
   - php -r "readfile('https://getcomposer.org/installer');" | php -- --filename=composer
-  - php composer config -g github-oauth.github.com "%COMPOSER_OAUTH_TOKEN%"
+  - ps: >-
+      If ($Env:COMPOSER_OAUTH_TOKEN -ne '') {
+        php composer config -g -- github-oauth.github.com "$Env:COMPOSER_OAUTH_TOKEN"
+      }
   - SET PATH=%APPDATA%\Composer\vendor\bin;%PATH%
   # Install PHPMD
   - php composer global require "phpmd/phpmd"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,12 +17,12 @@ install:
   - net start wuauserv
   # The following installs and sets up PHP
   - cinst -y php
-  - cd c:\tools\php72
+  - cd c:\tools\php73
   - copy php.ini-production php.ini
   - echo date.timezone="UTC" >> php.ini
   - echo extension_dir=ext >> php.ini
   - echo extension=php_openssl.dll >> php.ini
-  - SET PATH=C:\tools\php72\;%PATH%
+  - SET PATH=C:\tools\php73\;%PATH%
   # Install Composer
   - php -r "readfile('https://getcomposer.org/installer');" | php -- --filename=composer
   - ps: >-


### PR DESCRIPTION
This updates the CI configuration to get things working again.

AppVeyor:
* Use an encrypted `COMPOSER_OAUTH_TOKEN`
* Use PHP 7.3

Travis CI:
* Remove old token, updated one specified in web settings
* Update Composer vendor path