### PR TITLE
Guard against missing tokens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,11 @@ jobs:
           - npx semantic-release
 
 install:
-  # Set the GitHub OAuth token for Composer
-  - composer config -g github-oauth.github.com "$COMPOSER_OAUTH_TOKEN"
+  # Set the GitHub OAuth token for Composer if it is available
+  - |
+    if [[ -n "$COMPOSER_OAUTH_TOKEN" ]]; then
+      composer config -g github-oauth.github.com "$COMPOSER_OAUTH_TOKEN";
+    fi
   - export PATH="$PATH:$HOME/.config/composer/vendor/bin"
   # Install PHPMD
   - composer global require "phpmd/phpmd"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   # Install Composer
   - php -r "readfile('https://getcomposer.org/installer');" | php -- --filename=composer
   - ps: >-
-      If ($Env:COMPOSER_OAUTH_TOKEN -ne '') {
+      If (Test-Path variable:global:COMPOSER_OAUTH_TOKEN) {
         php composer config -g -- github-oauth.github.com "$Env:COMPOSER_OAUTH_TOKEN"
       }
   - SET PATH=%APPDATA%\Composer\vendor\bin;%PATH%


### PR DESCRIPTION
PR's from outside collaborators are failing the build as they are unable to set the token for `composer`. Guard against this so it is only set if available, letting these builds fall back to the public access.

This was missed in #131.